### PR TITLE
Legacy: Add back legacy ctrl so you can enable app

### DIFF
--- a/src/dashboards/stats.json
+++ b/src/dashboards/stats.json
@@ -85,7 +85,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Panel Title3",
+      "title": "Panel Title",
       "type": "stat"
     }
   ],

--- a/src/dashboards/stats.json
+++ b/src/dashboards/stats.json
@@ -85,8 +85,8 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Panel Title",
-      "type": "singlestat2"
+      "title": "Panel Title3",
+      "type": "stat"
     }
   ],
   "schemaVersion": 18,
@@ -104,7 +104,8 @@
     "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
   },
   "timezone": "",
-  "title": "stats",
+  "title": "Starter App - Stats",
   "uid": "YeBxHjzWz",
-  "version": 1
+  "revision": 3,
+  "version": 3
 }

--- a/src/dashboards/streaming.json
+++ b/src/dashboards/streaming.json
@@ -58,8 +58,8 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Simple dummy streaming example",
-      "type": "graph2"
+      "title": "Simple dummy streaming example4",
+      "type": "timeseries"
     }
   ],
   "schemaVersion": 18,
@@ -77,7 +77,8 @@
     "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
   },
   "timezone": "",
-  "title": "simple streaming",
+  "title": "Starter App - Streaming",
   "uid": "TbbEZjzWz",
-  "version": 1
+  "revision": 4,
+  "version": 4
 }

--- a/src/dashboards/streaming.json
+++ b/src/dashboards/streaming.json
@@ -58,7 +58,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Simple dummy streaming example4",
+      "title": "Simple dummy streaming example",
       "type": "timeseries"
     }
   ],

--- a/src/legacy/config.ts
+++ b/src/legacy/config.ts
@@ -1,0 +1,36 @@
+import { PluginMeta } from '@grafana/data';
+
+export class ExampleConfigCtrl {
+  static template = '<h2><hello/h2>';
+
+  appEditCtrl: any;
+  appModel?: PluginMeta;
+
+  /** @ngInject */
+  constructor($scope: any, $injector: any) {
+    this.appEditCtrl.setPostUpdateHook(this.postUpdate.bind(this));
+
+    // Make sure it has a JSON Data spot
+    if (!this.appModel) {
+      this.appModel = {} as PluginMeta;
+    }
+
+    // Required until we get the types sorted on appModel :(
+    const appModel = this.appModel as any;
+    if (!appModel.jsonData) {
+      appModel.jsonData = {};
+    }
+
+    console.log('ExampleConfigCtrl', this);
+  }
+
+  postUpdate() {
+    if (!this.appModel?.enabled) {
+      console.log('Not enabled...');
+      return;
+    }
+
+    // TODO, can do stuff after update
+    console.log('Post Update:', this);
+  }
+}

--- a/src/legacy/config.ts
+++ b/src/legacy/config.ts
@@ -1,7 +1,7 @@
 import { PluginMeta } from '@grafana/data';
 
 export class ExampleConfigCtrl {
-  static template = '<h2><hello/h2>';
+  static template = '<h2>hello</h2>';
 
   appEditCtrl: any;
   appModel?: PluginMeta;

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,10 +1,12 @@
 import { ComponentClass } from 'react';
-
+import { ExampleConfigCtrl } from './legacy/config';
 import { AppPlugin, AppRootProps } from '@grafana/data';
 import { ExamplePage1 } from './config/ExamplePage1';
 import { ExamplePage2 } from './config/ExamplePage2';
 import { ExampleRootPage } from './ExampleRootPage';
 import { ExampleAppSettings } from './types';
+
+export { ExampleConfigCtrl as ConfigCtrl };
 
 export const plugin = new AppPlugin<ExampleAppSettings>()
   .setRootPage((ExampleRootPage as unknown) as ComponentClass<AppRootProps>)

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -27,7 +27,7 @@
     {
       "type": "page",
       "name": "Root Page (react)",
-      "path": "/a/yourorg-simple-app",
+      "path": "/a/myorgid-simple-app",
       "role": "Viewer",
       "addToNav": true,
       "defaultNav": true
@@ -35,14 +35,14 @@
     {
       "type": "page",
       "name": "Root Page (Tab B)",
-      "path": "/a/yourorg-simple-app/?tab=b",
+      "path": "/a/myorgid-simple-app/?tab=b",
       "role": "Viewer",
       "addToNav": true
     },
     {
       "type": "page",
       "name": "React Config",
-      "path": "/plugins/yourorg-simple-app/?page=page2",
+      "path": "/plugins/myorgid-simple-app/?page=page2",
       "role": "Admin",
       "addToNav": true
     },


### PR DESCRIPTION
Currently there is no way to enable app (view config page) without a angular config controller
